### PR TITLE
feat(deps): upgrade `@vscode/codicons` to v0.0.33

### DIFF
--- a/ICON_INDEX.md
+++ b/ICON_INDEX.md
@@ -1,6 +1,6 @@
 # Icon Index
 
-> 421 total icons
+> 426 total icons
 
 ## Icons
 
@@ -57,11 +57,11 @@
 - ChromeRestore
 - CircleFilled
 - CircleLargeFilled
-- CircleLargeOutline
-- CircleOutline
+- CircleLarge
 - CircleSlash
 - CircleSmallFilled
 - CircleSmall
+- Circle
 - CircuitBoard
 - ClearAll
 - Clippy
@@ -75,6 +75,7 @@
 - ColorMode
 - Combine
 - CommentDiscussion
+- CommentDraft
 - CommentUnresolved
 - Comment
 - CompassActive
@@ -196,6 +197,7 @@
 - Inbox
 - Indent
 - Info
+- Insert
 - Inspect
 - IssueDraft
 - IssueReopened
@@ -325,8 +327,10 @@
 - Save
 - ScreenFull
 - ScreenNormal
+- SearchFuzzy
 - SearchStop
 - Search
+- Send
 - ServerEnvironment
 - ServerProcess
 - Server
@@ -338,6 +342,7 @@
 - Smiley
 - SortPrecedence
 - SourceControl
+- Sparkle
 - SplitHorizontal
 - SplitVertical
 - Squirrel

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.1.1",
-    "@vscode/codicons": "0.0.32",
+    "@vscode/codicons": "0.0.33",
     "gh-pages": "^5.0.0",
     "svelte": "^3.58.0",
     "svelte-check": "^3.2.0",

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Library > has exports 1`] = `
+exports[`Library > has exports 2`] = `
 [
   "Account",
   "ActivateBreakpoints",
@@ -55,11 +55,11 @@ exports[`Library > has exports 1`] = `
   "ChromeRestore",
   "CircleFilled",
   "CircleLargeFilled",
-  "CircleLargeOutline",
-  "CircleOutline",
+  "CircleLarge",
   "CircleSlash",
   "CircleSmallFilled",
   "CircleSmall",
+  "Circle",
   "CircuitBoard",
   "ClearAll",
   "Clippy",
@@ -73,6 +73,7 @@ exports[`Library > has exports 1`] = `
   "ColorMode",
   "Combine",
   "CommentDiscussion",
+  "CommentDraft",
   "CommentUnresolved",
   "Comment",
   "CompassActive",
@@ -194,6 +195,7 @@ exports[`Library > has exports 1`] = `
   "Inbox",
   "Indent",
   "Info",
+  "Insert",
   "Inspect",
   "IssueDraft",
   "IssueReopened",
@@ -323,8 +325,10 @@ exports[`Library > has exports 1`] = `
   "Save",
   "ScreenFull",
   "ScreenNormal",
+  "SearchFuzzy",
   "SearchStop",
   "Search",
+  "Send",
   "ServerEnvironment",
   "ServerProcess",
   "Server",
@@ -336,6 +340,7 @@ exports[`Library > has exports 1`] = `
   "Smiley",
   "SortPrecedence",
   "SourceControl",
+  "Sparkle",
   "SplitHorizontal",
   "SplitVertical",
   "Squirrel",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -11,7 +11,7 @@ describe("Library", () => {
     expect(API.default).toBeUndefined();
 
     const exports = Object.keys(API);
-    expect(exports.length).toEqual(421);
+    expect(exports.length).toMatchInlineSnapshot("426");
     expect(exports).toMatchSnapshot();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,10 +328,10 @@
     loupe "^2.3.6"
     pretty-format "^27.5.1"
 
-"@vscode/codicons@0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.32.tgz#9e27de90d509c69762b073719ba3bf46c3cd2530"
-  integrity sha512-3lgSTWhAzzWN/EPURoY4ZDBEA80OPmnaknNujA3qnI4Iu7AONWd9xF3iE4L+4prIe8E3TUnLQ4pxoaFTEEZNwg==
+"@vscode/codicons@0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@vscode/codicons/-/codicons-0.0.33.tgz#a56243ab5492801fff04e53c0aab0d18a6521751"
+  integrity sha512-VdgpnD75swH9hpXjd34VBgQ2w2quK63WljodlUcOoJDPKiV+rPjHrcUc2sjLCNKxhl6oKqmsZgwOWcDAY2GKKQ==
 
 acorn-walk@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
- Upgrade `@vscode/codicons` to [v0.0.33](https://github.com/microsoft/vscode-codicons/releases/tag/0.0.33) (net +5 icons)